### PR TITLE
Change symfony-cmf/routing version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.4",
-        "symfony-cmf/routing": "^1.2",
+        "symfony-cmf/routing": "^1.2 || ^2.2",
         "aferrandini/urlizer": "1.0.*"
     },
     "require-dev": {


### PR DESCRIPTION
`"symfony-cmf/routing": "^1.2"` doesn't support Symfony 4+